### PR TITLE
Add Feature: List Categories

### DIFF
--- a/loaddata.sql
+++ b/loaddata.sql
@@ -88,3 +88,7 @@ INSERT INTO Categories ('label') VALUES ('News');
 INSERT INTO Tags ('label') VALUES ('JavaScript');
 INSERT INTO Reactions ('label', 'image_url') VALUES ('happy', 'https://pngtree.com/so/happy');
 INSERT INTO Posts ('user_id', 'category_id', 'title', 'publication_date' ,'image_url', 'content', 'approved') VALUES (1, 1, 'Test Title', 0420222, 'https://i.kym-cdn.com/entries/icons/facebook/000/013/564/doge.jpg', 'this is a test of the post system', 1 );
+
+
+INSERT INTO Categories ('label') VALUES ('Sports');
+INSERT INTO Categories ('label') VALUES ('Music');

--- a/loaddata.sql
+++ b/loaddata.sql
@@ -92,3 +92,11 @@ INSERT INTO Posts ('user_id', 'category_id', 'title', 'publication_date' ,'image
 
 INSERT INTO Categories ('label') VALUES ('Sports');
 INSERT INTO Categories ('label') VALUES ('Music');
+INSERT INTO Categories ('label') VALUES ('Alchemy');
+INSERT INTO Categories ('label') VALUES ('Whiskey');
+INSERT INTO Categories ('label') VALUES ('Legos');
+SELECT
+            ca.id,
+            ca.label
+        FROM Categories AS ca
+        ORDER BY ca.label ASC;

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,8 +1,5 @@
-from .post import Post
-<<<<<<< HEAD
-from .categories import Categories
-=======
 from .category import Category
+from .post import Post
+from .categories import Categories
 from .user import User
 from .tag import Tag
->>>>>>> 1b55c0a71b63952dc631f53ceadf9f5da47bcbca

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,1 +1,2 @@
 from .post import Post
+from .categories import Categories

--- a/models/categories.py
+++ b/models/categories.py
@@ -1,0 +1,5 @@
+class Categories():
+    def __init__(self, id, label):
+        self.id = id
+        self.label = label
+        

--- a/request_handler.py
+++ b/request_handler.py
@@ -2,6 +2,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
 from views import get_all_posts, get_single_post
 from views.user import create_user, login_user
+from views.categories import get_all_categories, get_single_category
 
 
 class HandleRequests(BaseHTTPRequestHandler):
@@ -68,6 +69,11 @@ class HandleRequests(BaseHTTPRequestHandler):
                     response = f"{get_single_post(id)}"
                 else:
                     response = f"{get_all_posts()}"
+            elif resource == "categories":
+                if id is not None:
+                    response = f"{get_single_category(id)}"
+                else:
+                    response = f"{get_all_categories()}"
                     
         elif len(parsed) == 3:
             ( resource, key, value ) = parsed

--- a/request_handler.py
+++ b/request_handler.py
@@ -1,13 +1,9 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
-from views import get_all_posts, get_single_post, create_post
+from views.posts_requests import get_all_posts, get_single_post, create_post
 from views.user import create_user, login_user
-<<<<<<< HEAD
 from views.categories import get_all_categories, get_single_category
-=======
-from views import get_all_tags, get_single_tag
->>>>>>> 1b55c0a71b63952dc631f53ceadf9f5da47bcbca
-
+from views.tags_requests import get_all_tags, get_single_tag
 
 class HandleRequests(BaseHTTPRequestHandler):
     """Handles the requests to this server"""
@@ -73,21 +69,18 @@ class HandleRequests(BaseHTTPRequestHandler):
                     response = f"{get_single_post(id)}"
                 else:
                     response = f"{get_all_posts()}"
-<<<<<<< HEAD
             elif resource == "categories":
                 if id is not None:
                     response = f"{get_single_category(id)}"
                 else:
                     response = f"{get_all_categories()}"
                     
-=======
-            if resource == "tags":
+            elif resource == "tags":
                 if id is not None:
                     response = f"{get_single_tag(id)}"
                 else:
                     response = f"{get_all_tags()}"
 
->>>>>>> 1b55c0a71b63952dc631f53ceadf9f5da47bcbca
         elif len(parsed) == 3:
             ( resource, key, value ) = parsed
 

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,1 +1,2 @@
 from .posts_requests import get_all_posts, get_single_post
+from .categories import get_all_categories, get_single_category

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,7 +1,3 @@
-<<<<<<< HEAD
-from .posts_requests import get_all_posts, get_single_post
 from .categories import get_all_categories, get_single_category
-=======
 from .posts_requests import get_all_posts, get_single_post, create_post
 from .tags_requests import get_all_tags, get_single_tag
->>>>>>> 1b55c0a71b63952dc631f53ceadf9f5da47bcbca

--- a/views/categories.py
+++ b/views/categories.py
@@ -1,0 +1,49 @@
+import sqlite3
+import json
+from models import Categories, categories
+
+
+def get_all_categories():
+    with sqlite3.connect("./db.sqlite3") as conn:
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        SELECT
+            ca.id,
+            ca.label
+        FROM Categories AS ca
+        ORDER BY ca.label ASC
+        """)
+
+        categories = []
+
+        dataset = db_cursor.fetchall()
+
+        for row in dataset:
+            cat = Categories(row['id'], row['label'])
+
+            categories.append(cat.__dict__)
+
+    return json.dumps(categories)
+
+
+def get_single_category(id):
+    with sqlite3.connect("./db.sqlite3") as conn:
+
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        SELECT
+            ca.id,
+            ca.label
+            FROM Categories AS ca
+            WHERE ca.id = ?
+            """, (id,))
+
+        data = db_cursor.fetchone()
+
+        categories = Categories(data['id'], data['label'])
+
+        return json.dumps(categories.__dict__)


### PR DESCRIPTION
# Description

This change provides a new item on the navbar `Category Manager`, which, when clicked, uses the `/categories` route to retrieve/display the categories for the posts. 
This is change on both the client side and the server side.

Fixes #22 “View Category List”

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested by either/both:
- clicking the `Category Manager` link in the navbar, and/or 
- going directly to the URL `http://localhost:8088/categories` as a logged-in user.

[ ] verify that categories are displayed (e.g.: Category: News) in a list
[ ] verify that categories are displayed alphabetically (A-Z order). Add additional categories to the database if needed.
[ ] verify that each category has an `Edit` and `Delete` button adjacent to them. The buttons will be nonfunctional at this time.
