### PR TITLE
Created Categories Form [ gsh-categoriesForm ]

### DIFF
--- a/request_handler.py
+++ b/request_handler.py
@@ -4,9 +4,8 @@ from views import get_all_posts, get_single_post, create_post, get_user_posts
 from views.posts_requests import delete_post
 from views.user import create_user, login_user
 from views import get_all_tags, get_single_tag, create_tag
-
-from views.categories import get_all_categories, get_single_category
-
+from views.categories import add_category, get_all_categories, get_single_category
+from views.categories import delete_category, add_category
 
 class HandleRequests(BaseHTTPRequestHandler):
     """Handles the requests to this server"""
@@ -111,6 +110,8 @@ class HandleRequests(BaseHTTPRequestHandler):
             response = create_post(post_body)
         if resource == "tags":
             response = create_tag(post_body)
+        if resource == "categories":
+            response = add_category(post_body)
 
         self.wfile.write(f"{response}".encode())
 
@@ -125,6 +126,8 @@ class HandleRequests(BaseHTTPRequestHandler):
         
         if resource == "posts":
             delete_post(id)
+        elif resource == "categories":
+            delete_category(id)
         
         self.wfile.write("".encode())
 

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,3 +1,4 @@
-from .categories import get_all_categories, get_single_category
+from .categories import delete_category, get_all_categories, get_single_category
+from .categories import delete_category, add_category
 from .posts_requests import get_all_posts, get_single_post, create_post, get_user_posts, delete_post
 from .tags_requests import get_all_tags, get_single_tag, create_tag

--- a/views/__init__.py
+++ b/views/__init__.py
@@ -1,7 +1,7 @@
 from .categories import delete_category, get_all_categories, get_single_category
 from .categories import delete_category, add_category
 from .posts_requests import get_all_posts, get_single_post, create_post, get_user_posts, delete_post
-from .categories import get_all_categories, get_single_category
+from .categories import get_all_categories, get_single_category, add_category
 from .posts_requests import get_all_posts, get_single_post, create_post, get_user_posts, delete_post, update_post
 from .tags_requests import get_all_tags, get_single_tag, create_tag
 from .users_requests import get_all_users

--- a/views/categories.py
+++ b/views/categories.py
@@ -68,7 +68,7 @@ def delete_category(id):
 
         return json.dumps(categories.__dict__)
     
-def add_category(label):
+def add_category(new_category):
     """FN to add a new category to the DB"""
     with sqlite3.connect("./db.sqlite3") as conn:
 
@@ -77,14 +77,11 @@ def add_category(label):
 
         db_cursor.execute("""
         INSERT
-            ca.label
-            INTO Categories AS ca
-            VALUES ca.label = ?
-            """, (label,))
+            INTO Categories ( label )
+            VALUES ( ? )
+            """, (new_category['label'], ))
 
-        data = db_cursor.fetchone()
+        id = db_cursor.lastrowid
+        new_category['id'] = id
 
-        categories = Categories(data['id'], data['label'])
-
-        return json.dumps(categories.__dict__)
-    
+        return json.dumps(new_category)

--- a/views/categories.py
+++ b/views/categories.py
@@ -1,3 +1,4 @@
+from cProfile import label
 import sqlite3
 import json
 from models import Categories, categories
@@ -47,3 +48,43 @@ def get_single_category(id):
         categories = Categories(data['id'], data['label'])
 
         return json.dumps(categories.__dict__)
+
+def delete_category(id):
+    """FN to delete a row in the DB based on id"""
+    with sqlite3.connect("./db.sqlite3") as conn:
+
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        DELETE
+            FROM Categories AS ca
+            WHERE ca.id = ?
+            """, (id,))
+
+        data = db_cursor.fetchone()
+
+        categories = Categories(data['id'], data['label'])
+
+        return json.dumps(categories.__dict__)
+    
+def add_category(label):
+    """FN to add a new category to the DB"""
+    with sqlite3.connect("./db.sqlite3") as conn:
+
+        conn.row_factory = sqlite3.Row
+        db_cursor = conn.cursor()
+
+        db_cursor.execute("""
+        INSERT
+            ca.label
+            INTO Categories AS ca
+            VALUES ca.label = ?
+            """, (label,))
+
+        data = db_cursor.fetchone()
+
+        categories = Categories(data['id'], data['label'])
+
+        return json.dumps(categories.__dict__)
+    


### PR DESCRIPTION
# Description

This change provides a form on the `/categories` route for creating a new category. 
This is change on both the client side and the server side.

Fixes #20 “Create a Category”

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested by:
- Get the matching branch from the client side
- either/both:
  - - clicking the `Category Manager` link in the navbar, and/or 
  - - going directly to the URL `http://localhost:8088/categories` as a logged-in user.
- fill in the provided form and click submit.

[ ] verify that categories are still displayed (e.g.: Category: News) in a list
[ ] verify that categories are still displayed alphabetically (A-Z order). Add additional categories to the database if needed.
[ ] verify that each category has an `Edit` and `Delete` button adjacent to them. The buttons will be nonfunctional at this time.
[ ] verify that there is a form to the right of the list.
[ ] verify that you can enter a new category, click `Submit`, the page refreshes with all the categories, including your newly added category, and that they’re still in alphabetic order.